### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sfs-diagnose.yml
+++ b/.github/workflows/sfs-diagnose.yml
@@ -1,5 +1,7 @@
 name: SFS Diagnose
 on: { workflow_dispatch: {} }
+permissions:
+  contents: read
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/smartflow-systems/SmartFlowSite/security/code-scanning/10](https://github.com/smartflow-systems/SmartFlowSite/security/code-scanning/10)

The best fix is to add a top-level `permissions` block near the top of the workflow file, specifying the minimum required permissions to run this workflow. Since the workflow only prints repository and secret information (but does not make any write/API actions), `contents: read` is safe and sufficient. The new block should go immediately after the `name:` and `on:` sections and before `jobs:` (usually after `on:`), or alternatively at the start of the `check:` job (but root-level is standard and applies to all jobs by default).

**Specific steps:**
- Insert the following after the `on:` block (after line 2):
  ```yaml
  permissions:
    contents: read
  ```
- This grants the least privilege: only read-level access to repository contents.

No additional imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
