### PR TITLE
Potential fix for code scanning alert no. 4: Uncontrolled command line

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,12 +1,12 @@
 import express from 'express';
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 const app = express(); app.use(express.json());
 
 app.post('/gh-sync', (req, res) => {
   if ((req.get('authorization')||'') !== `Bearer ${process.env.SYNC_TOKEN}`)
     return res.status(401).json({ok:false});
   const ref = (req.body?.ref as string) || 'main';
-  exec(`bash scripts/sync.sh ${ref}`, (err, out, errout) =>
+  execFile('bash', ['scripts/sync.sh', ref], (err, out, errout) =>
     err ? res.status(500).json({ok:false, err:String(errout||err)})
         : res.json({ok:true, ref}));
 });


### PR DESCRIPTION
Potential fix for [https://github.com/smartflow-systems/SmartFlowSite/security/code-scanning/4](https://github.com/smartflow-systems/SmartFlowSite/security/code-scanning/4)

To fix this problem, we need to prevent untrusted user input from being interpolated in a shell command line. The best way is to avoid shell invocation entirely, using an API that does not spawn a shell and instead accepts commands and arguments as an array, such as `child_process.execFile` or `child_process.spawn`. This means we should call the `bash` program with array arguments, or even better, call the target script directly if it has a shebang.

**Steps:**  
- Replace `exec` with `execFile` (from the same module).  
- Pass the script file and the arguments as individual elements in the array.  
- If you need to use `bash`, pass `scripts/sync.sh` and `[ref]` as arguments to it, i.e., `execFile('bash', ['scripts/sync.sh', ref], ...)`.  
- This prevents any shell expansion or interpretation of special characters, avoiding command injection.
- No need for additional dependencies unless argument parsing (which is not present in this snippet) is required.
- Only lines 2, 9 (and potentially surrounding context, if needed) in server/index.ts will be touched.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
