### PR TITLE
Potential fix for code scanning alert no. 6: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "echo 'no build step' && exit 0",
     "test": "echo 'no tests' && exit 0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "express-rate-limit": "^8.1.0"
+  },
   "devDependencies": {},
   "engines": {
     "node": ">=18"

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,8 +1,17 @@
 import express from 'express';
 import { exec } from 'child_process';
+import rateLimit from 'express-rate-limit';
 const app = express(); app.use(express.json());
 
-app.post('/gh-sync', (req, res) => {
+// Rate limit for /gh-sync: 5 requests per 5 minutes per IP
+const syncLimiter = rateLimit({
+  windowMs: 5 * 60 * 1000, // 5 minutes
+  max: 5, // limit each IP to 5 requests per windowMs
+  standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+  legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+});
+
+app.post('/gh-sync', syncLimiter, (req, res) => {
   if ((req.get('authorization')||'') !== `Bearer ${process.env.SYNC_TOKEN}`)
     return res.status(401).json({ok:false});
   const ref = (req.body?.ref as string) || 'main';


### PR DESCRIPTION
Potential fix for [https://github.com/smartflow-systems/SmartFlowSite/security/code-scanning/6](https://github.com/smartflow-systems/SmartFlowSite/security/code-scanning/6)

To fix the problem, we should use a proven rate-limiting middleware such as `express-rate-limit`.  
- Add an import for `express-rate-limit`.
- Create a rate-limiter instance. Reasonable defaults: e.g., max 5 requests per 5 minutes per IP.
- Apply this rate-limiter only to the `/gh-sync` endpoint (not globally), by adding it as middleware to the specific route.
- The rest of the code can remain unchanged, ensuring no impact on existing logic or authorization.

All changes are confined to the provided `server/index.ts` code; specifically, we add a new import at the top, instantiate the rate limiter above the route definition, and add the middleware to the route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
