### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: SFS CI
+permissions:
+  contents: read
 on:
   workflow_call:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/smartflow-systems/SmartFlowSite/security/code-scanning/9](https://github.com/smartflow-systems/SmartFlowSite/security/code-scanning/9)

The best way to fix this issue is to add a `permissions` block explicitly limiting the permissions of the `GITHUB_TOKEN` to the minimum needed. For this workflow, which only builds and tests code, the minimum is likely `contents: read`. This block should be added at the workflow level (after the `name` and before or after `on:`) so that it applies to all jobs unless otherwise overridden. This does not alter any job functionality.

**Steps:**
1. Edit `.github/workflows/ci.yml`.
2. Add  
   ```yaml
   permissions:
     contents: read
   ```  
   after the `name: SFS CI` line (either above or below the `on:` block, but conventionally immediately after `name:`).
3. No additional libraries or packages are needed.
4. No further code changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
