### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: SFS CI Deploy
+permissions:
+  contents: read
 on: { push: { branches: [ main ] } }
 jobs:
   deploy:


### PR DESCRIPTION
Potential fix for [https://github.com/smartflow-systems/SmartFlowSite/security/code-scanning/7](https://github.com/smartflow-systems/SmartFlowSite/security/code-scanning/7)

To fix this issue, we need to explicitly declare a `permissions` block in `.github/workflows/deploy.yml`, at either the root workflow level or (less commonly, but possible) inside the `jobs.deploy` block. Since only one job is present, it's simplest and clearest to declare it at the workflow root, which will apply to all jobs unless overridden. The exact minimal permissions required depend on what the called workflow (`sfs-ci-deploy.yml`) does; however, as a starting point and following principle of least privilege, we should set `contents: read`. If the workflow needs more (for example, `pull-requests: write`), this can be added later. Therefore, insert the following after the workflow `name` and before `on`:

```yaml
permissions:
  contents: read
```

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
