### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sf-shellcheck.yml
+++ b/.github/workflows/sf-shellcheck.yml
@@ -1,4 +1,6 @@
 name: SmartFlow Tools Lint
+permissions:
+  contents: read
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/smartflow-systems/SmartFlowSite/security/code-scanning/8](https://github.com/smartflow-systems/SmartFlowSite/security/code-scanning/8)

To fix this problem, you should explicitly add a `permissions` block to the workflow, ideally at the root level so that it applies to all jobs. Because this workflow only checks out code and runs a linter, the minimal required permissions are `contents: read` (for `actions/checkout` to work). Insert the block `permissions: contents: read` right after the `name` field and before the `on` field at the top of `.github/workflows/sf-shellcheck.yml`. No new methods, imports, or further definitions are required—just this YAML edit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
