### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,7 +38,15 @@ def health():
 
 @app.route("/data/<path:fname>")
 def data_files(fname: str):
-    p = BASE / "data" / fname
+    data_root = BASE / "data"
+    # Normalize and resolve the final path
+    try:
+        p = (data_root / fname).resolve()
+    except Exception:
+        abort(404)
+    # Ensure the requested file is within the data directory
+    if not str(p).startswith(str(data_root)):
+        abort(403)
     if not p.exists():
         abort(404)
     return send_from_directory(p.parent, p.name)


### PR DESCRIPTION
Potential fix for [https://github.com/smartflow-systems/SmartFlowSite/security/code-scanning/3](https://github.com/smartflow-systems/SmartFlowSite/security/code-scanning/3)

To fix the issue, we need to ensure that any file served via the `/data/<path:fname>` route is located strictly within the `BASE/data` directory tree. This requires normalizing the user-controlled path and confirming it's a strict subpath of the allowed root (`BASE/data`). Specifically:
- After constructing the full path, use `os.path.normpath` (or `Path.resolve()` if using pathlib) to eliminate traversal components (e.g., `..`).
- Check that the resolved path is a descendant of `BASE/data` before serving the file.
- If not, reject the request with a 404 or 403 error.
All changes will be within the `/data/<path:fname>` route in `app.py`. For maximum clarity and maintainability, use pathlib’s `resolve()` (with appropriate try/except on non-existent files) or `os.path.normpath` plus explicit string prefix check.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
