### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,8 +38,9 @@ def health():
 
 @app.route("/data/<path:fname>")
 def data_files(fname: str):
-    p = BASE / "data" / fname
-    if not p.exists():
+    data_base = (BASE / "data").resolve()
+    p = (data_base / fname).resolve()
+    if not str(p).startswith(str(data_base) + os.sep) or not p.exists():
         abort(404)
     return send_from_directory(p.parent, p.name)
 


### PR DESCRIPTION
Potential fix for [https://github.com/smartflow-systems/SmartFlowSite/security/code-scanning/2](https://github.com/smartflow-systems/SmartFlowSite/security/code-scanning/2)

The best way to fix this issue is to ensure that the constructed file path for data files (p = BASE / "data" / fname) always remains within the intended data directory, no matter what the user submits. To do this:

1. Normalize the full constructed path using `resolve()`.
2. Check that the resolved path starts with the intended root directory (i.e., `BASE / "data"`).
3. Reject requests where the normalized path does not match the intended base (with 404 or a security error).
4. Only then, open and send the file requested.

For minimal code change and security, modify the `/data/<path:fname>` route to normalize and check `p`. Add a definition for the safe base directory (e.g., `data_base = BASE / "data"`), and ensure that all resolved paths are within it.

No new imports are required—usage of `pathlib` and standard python path checks are sufficient.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
