### PR TITLE
ci: convert legacy sfs-ci-deploy to call-only wrapper (no push/PR trigger)

### DIFF
--- a/.github/workflows/sfs-ci-deploy.yml
+++ b/.github/workflows/sfs-ci-deploy.yml
@@ -1,53 +1,12 @@
-name: SFS CI + Deploy
+name: sfs-ci-deploy
 on:
-  push:
-    branches: [ main, dev ]
-  workflow_dispatch:
-
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: "pages"
-  cancel-in-progress: true
-
-env:
-  SFS_BUILD_CMD: "npm run build"
-  SFS_BUILD_DIR: "public"
-
+  workflow_call:
+    inputs:
+      python_version:
+        type: string
+        default: "3.11"
 jobs:
   ci:
-    uses: ./.github/workflows/ci.yml
-    secrets: inherit
-
-  build_pages:
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '18'
-          cache: 'npm'
-      - name: Install deps
-        run: npm ci || npm install
-      - name: Build
-        run: $SFS_BUILD_CMD
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ${{ env.SFS_BUILD_DIR }}
-
-  deploy:
-    if: github.ref == 'refs/heads/main'
-    needs: [ci, build_pages]
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+    uses: ./.github/workflows/reuse-sfs-ci.yml
+    with:
+      python_version: ${{ inputs.python_version }}


### PR DESCRIPTION
Retires old standalone sfs-ci-deploy.yml triggers; keeps the name as a reusable wrapper.

Delegates to reuse-sfs-ci.yml via workflow_call.

Reduces PR noise while preserving compatibility with any internal callers.