### PR TITLE
Update CI workflow to run reusable suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,28 +2,54 @@ name: ci
 
 on:
   push:
-    branches: [ "main", "tune/**" ]
+    branches:
+      - "main"
+      - "tune/**"
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - "main"
   workflow_dispatch: {}
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "build ok"
+  platform-ci:
+    name: Platform CI suite
+    uses: smartflow-systems/SmartFlowSite/.github/workflows/sfs-ci-deploy.yml@main
+    with:
+      service: smartflowsite
+      env: dev
+      python_version: "3.11"
+    secrets:
+      SFS_PAT: ${{ secrets.SFS_PAT }}
 
-  build_pages:
+  project-tests:
+    name: Project test and lint matrix
     runs-on: ubuntu-latest
+    needs: platform-ci
     steps:
-      - run: echo "build_pages ok"
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-  build-test:
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "build-test ok"
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
 
-  sfs-diagnose:
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "sfs-diagnose ok"
+      - name: Install Node.js dependencies
+        run: npm ci
+
+      - name: Run JavaScript tests
+        run: npm test -- --watch=false
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run Python tests
+        run: pytest

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,7 @@
+## VERIFY
+- Trigger the `ci` workflow via a pull request or the `workflow_dispatch` event and confirm that the reusable platform job and the project test job both complete successfully.
+- Inspect the workflow run to ensure `npm ci`, `npm test -- --watch=false`, and `pytest` steps execute without errors.
+
+## UNDO
+- Revert `.github/workflows/ci.yml` to the placeholder workflow that only emitted `echo` statements.
+- Remove the current entry from `docs/CHANGELOG.md` if the revert is intentional.


### PR DESCRIPTION
## Summary
- replace placeholder CI jobs with a call to the shared SmartFlow reusable workflow
- add project-specific Node.js and Python test steps so failures break the pipeline
- document the verification and undo steps for the updated workflow in the changelog

## Testing
- `npm ci`
- `npm test`
- `pytest`
- `pip install -r requirements.txt` *(fails: blocked from fetching packages in this environment)*

## Checklist
- [x] CI workflow updated to call reusable pipeline
- [x] CHANGELOG updated with VERIFY/UNDO instructions

## Files Touched
- .github/workflows/ci.yml
- docs/CHANGELOG.md

------
https://chatgpt.com/codex/tasks/task_e_68e1dc0be6a4832c86ef7234467d709f