### PR TITLE
Add default read permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: ci
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main", "tune/**" ]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,5 @@
+## VERIFY
+- CI workflow executes successfully with default read-only permissions.
+
+## UNDO
+- Remove the top-level `permissions` block from `.github/workflows/ci.yml` if broader access is required.


### PR DESCRIPTION
## Summary
- set the CI workflow's default permissions to read-only
- document the verification and undo guidance in the changelog

## Testing
- npm ci
- npm test
- pytest

## Checklist
- [x] Tests pass
- [x] CHANGELOG updated

## Files Touched
- .github/workflows/ci.yml
- docs/CHANGELOG.md

------
https://chatgpt.com/codex/tasks/task_e_68e1e30c9f04832cb7cf32b7bc6bd17e