### PR TITLE
Fix: Implement /health endpoint with site info & remove unused config

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,12 +1,25 @@
 import express from "express";
+import { readFileSync } from "fs";
+
 const app = express();
+
+// Load config once at startup
+const config = JSON.parse(readFileSync("./public/site.config.json", "utf-8"));
 
 // serve everything from /public
 app.use(express.static("public"));
 
-// health check (optional)
-app.get("/health", (_req, res) => res.json({ ok: true }));
-app.get("/api/health", (_req, res) => res.json({ ok: true }));
+// health check with site info
+app.get("/health", (_req, res) => res.json({
+  ok: true,
+  siteName: config.siteName,
+  version: config.version
+}));
+app.get("/api/health", (_req, res) => res.json({
+  ok: true,
+  siteName: config.siteName,
+  version: config.version
+}));
 
 // port
 const port = process.env.PORT || 5000;

--- a/site.config.json
+++ b/site.config.json
@@ -1,9 +1,0 @@
-{
-  "siteName": "SmartFlow Systems",
-  "description": "Professional automation solutions for modern businesses",
-  "version": "1.0.0",
-  "features": {
-    "leadCapture": true,
-    "emailNotifications": false
-  }
-}


### PR DESCRIPTION
## Summary
- ✅ Implement /health endpoint to expose siteName and version
- ✅ Remove unused root site.config.json that was causing confusion
- ✅ Load config from public/site.config.json (the actual used config)

## Problem
Commit 5da5384 updated `site.config.json` in root, but:
- Server serves from `/public` directory
- App fetches `site.config.json` → gets `/public/site.config.json`
- Root config was **never used** by the app
- /health endpoint didn't expose site info as intended

## Solution
1. Updated server.js to load config from `public/site.config.json`
2. /health and /api/health now return siteName and version
3. Removed unused root site.config.json to avoid confusion

## Test Results
```bash
curl /health
{
  "ok": true,
  "siteName": "SmartFlow Systems",
  "version": "1.0.0"
}
```

## Files Changed
- `server.js`: Added config loading and updated health endpoints
- `site.config.json`: Removed (unused)

🤖 Generated with [Claude Code](https://claude.com/claude-code)