### PR TITLE
fix(devops): enforce strict codex verify and doctor checks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,42 +1,22 @@
-<!-- SmartFlow Systems — PR Template -->
-
 ## Summary
-<!-- What changed & why (one or two lines) -->
+- What changed:
+- Why:
 
-## Linked Issues
-Closes #
+## SmartFlow Checklist
+- [ ] Branch name follows `codex/{feature}-{date}{time}` (Europe/London)
+- [ ] Commit messages follow `feat|fix|chore(scope): message`
+- [ ] `npm ci` completed
+- [ ] `npm test` completed
+- [ ] `pytest` completed when `app.py` exists
+- [ ] No unsafe `innerHTML`; sanitization and ARIA reviewed
+- [ ] `docs/CHANGELOG.md` updated with VERIFY and UNDO
+- [ ] Reusable CI reference: `smartflow-systems/SmartFlowSite/.github/workflows/sfs-ci-deploy.yml@main`
 
-## Type of change
-- [ ] Feature
-- [ ] Fix
-- [ ] Chore / CI
-- [ ] Docs
-- [ ] Refactor (no behavior change)
-- [ ] Security
+## Files Touched
+- 
 
-## Screenshots / Demos (optional)
-<!-- GIF/URL/Notes -->
+## VERIFY
+1. 
 
-## How to test
-1.
-2.
-3.
-**Expected:** `/health` → `{"ok":true}` (Replit port ${PORT:-5000})
-
-## CI & checks
-- Latest run: Actions tab shows ✅ green
-- Status checks required by ruleset pass (build/test)
-
-## Risk & rollback
-Risk: Low / Medium / High  
-Rollback: `git revert <merge_sha>` or redeploy previous tag
-
-## Checklist
-- [ ] Commits are **signed** and conventional (e.g., `feat:`, `fix:`)
-- [ ] Updated docs under `docs/` if needed
-- [ ] No secrets or keys in diff
-- [ ] Owner(s) reviewed (CODEOWNERS)
-- [ ] Linear history (squash merge only)
-
-## Notes for release (optional)
-<!-- Changelog line, migration, env vars -->
+## UNDO
+1. 

--- a/blog/barber-deposits-stop-no-shows-without-scaring-good-clients.html
+++ b/blog/barber-deposits-stop-no-shows-without-scaring-good-clients.html
@@ -7,9 +7,11 @@
 <meta name="description" content="A simple deposit flow that keeps your chair full and your clients happy.">
 <link rel="icon" href="/assets/favicon.svg">
 <link rel="stylesheet" href="/styles.css">
+    <link rel="stylesheet" href="/css/sfs-complete-theme.css">
 <meta property="og:title" content="Barber Deposits — Stop No-Shows Without Scaring Good Clients"><meta property="og:description" content="A simple deposit flow that keeps your chair full and your clients happy.">
 </head>
 <body>
+  <canvas id="circuit-canvas"></canvas>
 <header class="nav">
   <div class="brand"><img class="logo" src="/assets/smartflow-logo.png" alt=""><span>SmartFlow Systems</span></div>
   <nav>
@@ -38,5 +40,7 @@
   <div class="links"><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a></div>
 </footer>
 <script>document.getElementById('year').textContent = new Date().getFullYear()</script>
+    <script src="/js/sfs-circuit-flow.js"></script>
+    <script src="/js/sfs-hamburger-menu.js"></script>
 </body>
 </html>

--- a/blog/index.html
+++ b/blog/index.html
@@ -7,8 +7,8 @@
 <meta name="description" content="Tutorials, launches, and growth notes.">
 <link rel="icon" href="/assets/favicon.svg">
 <link rel="stylesheet" href="/styles.css">
-
     <link rel="stylesheet" href="/css/sfs-complete-theme.css">
+
 </head>
 <body>
   <canvas id="circuit-canvas"></canvas>

--- a/blog/launch-ai-social-bot-v1.html
+++ b/blog/launch-ai-social-bot-v1.html
@@ -7,9 +7,11 @@
 <meta name="description" content="First release of our AI Social Bot with presets for barbers, salons, and fitness.">
 <link rel="icon" href="/assets/favicon.svg">
 <link rel="stylesheet" href="/styles.css">
+    <link rel="stylesheet" href="/css/sfs-complete-theme.css">
 <meta property="og:title" content="Launch — AI Social Bot (v1)"><meta property="og:description" content="First release of our AI Social Bot with presets for barbers, salons, and fitness.">
 </head>
 <body>
+  <canvas id="circuit-canvas"></canvas>
 <header class="nav">
   <div class="brand"><img class="logo" src="/assets/smartflow-logo.png" alt=""><span>SmartFlow Systems</span></div>
   <nav>
@@ -39,5 +41,7 @@
   <div class="links"><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a></div>
 </footer>
 <script>document.getElementById('year').textContent = new Date().getFullYear()</script>
+    <script src="/js/sfs-circuit-flow.js"></script>
+    <script src="/js/sfs-hamburger-menu.js"></script>
 </body>
 </html>

--- a/blog/local-seo-for-trades-be-the-1-choice-in-your-area.html
+++ b/blog/local-seo-for-trades-be-the-1-choice-in-your-area.html
@@ -7,9 +7,11 @@
 <meta name="description" content="Win the map pack with a simple system: pages, proof, and speed.">
 <link rel="icon" href="/assets/favicon.svg">
 <link rel="stylesheet" href="/styles.css">
+    <link rel="stylesheet" href="/css/sfs-complete-theme.css">
 <meta property="og:title" content="Local SEO for Trades — Be the #1 Choice in Your Area"><meta property="og:description" content="Win the map pack with a simple system: pages, proof, and speed.">
 </head>
 <body>
+  <canvas id="circuit-canvas"></canvas>
 <header class="nav">
   <div class="brand"><img class="logo" src="/assets/smartflow-logo.png" alt=""><span>SmartFlow Systems</span></div>
   <nav>
@@ -37,5 +39,7 @@
   <div class="links"><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a></div>
 </footer>
 <script>document.getElementById('year').textContent = new Date().getFullYear()</script>
+    <script src="/js/sfs-circuit-flow.js"></script>
+    <script src="/js/sfs-hamburger-menu.js"></script>
 </body>
 </html>

--- a/blog/major-ai-automation-update-5-new-features.html
+++ b/blog/major-ai-automation-update-5-new-features.html
@@ -7,8 +7,8 @@
 <meta name="description" content="We've launched 5 game-changing features including AI review management, voice assistants, virtual queues, and AR try-on technology.">
 <link rel="icon" href="/assets/favicon.svg">
 <link rel="stylesheet" href="/styles.css">
+    <link rel="stylesheet" href="/css/sfs-complete-theme.css">
 <meta property="og:title" content="Major AI & Automation Update — 5 New Features"><meta property="og:description" content="We've launched 5 game-changing features including AI review management, voice assistants, virtual queues, and AR try-on technology.">
-  <link rel="stylesheet" href="/assets/css/smartflow-theme.css">
 </head>
 <body>
   <canvas id="circuit-canvas"></canvas>
@@ -29,7 +29,7 @@
 <h2>🤖 AI Review Response Manager</h2>
 <ul>
 <li><strong>Automatic Google/Yelp review responses</strong> with brand-appropriate replies</li>
-<li><strong>Sentiment analysis</strong> to prioritize urgent negative reviews  </li>
+<li><strong>Sentiment analysis</strong> to prioritize urgent negative reviews</li>
 <li><strong>Template library</strong> for different review types</li>
 <li>Saves hours of manual work while maintaining your brand voice</li>
 </ul>
@@ -71,6 +71,7 @@
   <div class="links"><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a></div>
 </footer>
 <script>document.getElementById('year').textContent = new Date().getFullYear()</script>
-  <script src="/assets/js/smartflow-app.js"></script>
+    <script src="/js/sfs-circuit-flow.js"></script>
+    <script src="/js/sfs-hamburger-menu.js"></script>
 </body>
 </html>

--- a/blog/salon-instagram-ideas-september-content-calendar-uk.html
+++ b/blog/salon-instagram-ideas-september-content-calendar-uk.html
@@ -7,8 +7,8 @@
 <meta name="description" content="A 4-week plan with hooks and CTAs that actually bring bookings in.">
 <link rel="icon" href="/assets/favicon.svg">
 <link rel="stylesheet" href="/styles.css">
+    <link rel="stylesheet" href="/css/sfs-complete-theme.css">
 <meta property="og:title" content="Salon Instagram Ideas — September Content Calendar (UK)"><meta property="og:description" content="A 4-week plan with hooks and CTAs that actually bring bookings in.">
-  <link rel="stylesheet" href="/assets/css/smartflow-theme.css">
 </head>
 <body>
   <canvas id="circuit-canvas"></canvas>
@@ -27,9 +27,9 @@
   <div style="color:#cbbf9b;margin:6px 0 16px">2025-08-20 · salon, instagram, content, calendar</div>
   <article class="card" style="padding:16px"><p><strong>Week themes</strong></p>
 <ol>
-<li>Back-to-work glow-ups  </li>
-<li>Autumn colour inspo  </li>
-<li>Self-care Sunday care tips  </li>
+<li>Back-to-work glow-ups</li>
+<li>Autumn colour inspo</li>
+<li>Self-care Sunday care tips</li>
 <li>&quot;Booked-out Friday&quot; urgency posts</li>
 </ol>
 <p>Post 5×/week: 2 reels, 2 photos, 1 carousel. CTA: <strong>Book this week</strong>.</p>
@@ -41,6 +41,7 @@
   <div class="links"><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a></div>
 </footer>
 <script>document.getElementById('year').textContent = new Date().getFullYear()</script>
-  <script src="/assets/js/smartflow-app.js"></script>
+    <script src="/js/sfs-circuit-flow.js"></script>
+    <script src="/js/sfs-hamburger-menu.js"></script>
 </body>
 </html>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,3 +15,35 @@
 ### UNDO
 - `git checkout -- package.json docs/CHANGELOG.md`
 - `npm ci`
+
+## 2026-05-21
+
+### Added
+- Added Codex operator scripts for standard branch creation and environment doctor checks.
+- Added a Codex setup runbook and reusable task prompt templates.
+- Standardized the pull request template with SmartFlow VERIFY/UNDO and files touched checklist.
+
+### Changed
+- Added `doctor`, `sfs:new-branch`, and `sfs:verify` npm scripts for consistent execution.
+
+### VERIFY
+- `npm run doctor`
+- `npm ci`
+- `npm test`
+- `pytest`
+
+### UNDO
+- `git checkout -- package.json .github/PULL_REQUEST_TEMPLATE.md docs/CHANGELOG.md docs/codex-setup.md docs/codex-prompts scripts/sfs-doctor.sh scripts/sfs-new-branch.sh`
+
+## 2026-05-21
+
+### Fixed
+- Hardened `scripts/sfs-doctor.sh` to fail fast when required npm scripts are missing instead of silently continuing.
+- Updated `sfs:verify` to run `npm ci` before `npm test` so verification follows SmartFlow install-first policy.
+
+### VERIFY
+- `npm run doctor`
+- `npm run sfs:verify`
+
+### UNDO
+- `git checkout -- package.json scripts/sfs-doctor.sh docs/CHANGELOG.md`

--- a/docs/Prompts-Library.md
+++ b/docs/Prompts-Library.md
@@ -1,1 +1,22 @@
-﻿ST: CONSOLIDATE / STATUS / FULL FILE [path] / ROLLBACK / DIAGNOSE / REWIND FROM HERE
+# Prompts Library
+
+## STATUS
+Give repo health, blockers, dirty files, CI state, deploy state, and next 3 steps.
+
+## CONSOLIDATE
+Create one Apply-All Bash block with verify and undo.
+
+## DIAGNOSE
+Find root cause first. Ask max 2 clarifiers only if blocked.
+
+## FULL FILE [path]
+Output the complete requested file.
+
+## ROLLBACK
+Undo the last safe/reversible action.
+
+## REWIND FROM HERE
+Restart from clean known state.
+
+## LET'S BASH
+Return direct bash commands with where to run, verify, and undo.

--- a/docs/SFS-MASTER-CONTEXT.md
+++ b/docs/SFS-MASTER-CONTEXT.md
@@ -1,0 +1,199 @@
+# SFS Master Context
+
+Single file with full SmartFlow Systems context.
+Use this to brief any AI tool cold — paste the whole thing.
+
+Last updated: 2026-03-28
+
+---
+
+## Who We Are
+
+SmartFlow Systems (SFS) is a SaaS ecosystem of 49 GitHub repositories
+covering social media automation, booking systems, data analytics,
+white-label dashboards, and AI-powered business tools for barbers,
+salons, and small service businesses.
+
+Owner: boweazy (Garet)
+Org: https://github.com/smartflow-systems
+Local workspace: /home/garet/SFS/
+Brand: black #0D0D0D / brown #3B2F2F / gold #FFD700 — never deviate
+
+---
+
+## Business Reality
+
+- 6 months building → £0 revenue, 0 customers
+- 8 products are production-ready
+- Problem is sales execution, not technical capability
+- Top priority: close first paying customer (barber/salon)
+- Do not start new builds until MRR > £1,000
+
+---
+
+## Stack
+
+Frontend:   React 18/19, TypeScript, Tailwind CSS, Radix UI, Lucide React
+Backend:    Node.js (Express), Python (FastAPI), Prisma ORM
+Database:   SQLite (dev), PostgreSQL (prod)
+AI/ML:      OpenAI GPT-4o-mini
+Payments:   Stripe, Stripe Connect
+Email:      SendGrid + SMTP
+Auth:       JWT, OAuth, RBAC (Owner/Admin/Staff/Analyst)
+Deploy:     Replit (primary), GitHub Actions CI/CD
+
+### NOT in the stack
+
+- ChromaDB — not implemented
+- ConvertKit — not implemented
+- Mailchimp — not implemented
+- LangChain — not implemented
+
+---
+
+## Source of Truth
+
+All CI/CD patterns come from SmartFlowSite:
+https://github.com/smartflow-systems/SmartFlowSite
+
+Standard health check: GET /health → {"ok":true}
+Standard CI file: .github/workflows/ci.yml
+
+---
+
+## Production-Ready Repos
+
+1. SmartFlowSite — main site + CI control
+2. Barber-booker-v1 — #1 sales priority
+3. SocialScaleBooster — #2 sales priority
+4. SocialScaleBoosterAIbot — AI bot builder
+5. SFS-SocialPowerhouse — wrong org, move to smartflow-systems
+6. DataQueryEngine — natural language to SQL
+7. DataScrapeInsights — scraping + insights
+8. sfs-analytics-engine — analytics backend
+
+---
+
+## Active Development Repos
+
+1. sfs-white-label-dashboard — wrong org, move to smartflow-systems
+2. smartflow-hub — unified dashboard + Claude integration
+3. sfs-revenue-analytics — revenue optimisation
+4. SFS-Backend — centralised API
+5. SFSAPDemoCRM — CRM + lead management
+6. sfs-marketing-and-growth — marketing + booking
+7. sfs-core-utils — shared utilities
+8. sfs-intelligence-engine — FastAPI AI
+9. AP-CRM — CRM
+10. sfs-social-content-generator — barber demo tool
+11. smartflow-systems-control-room — skill package
+12. SmartFlowSite real only — /home/garet/SFS/SmartFlowSite
+
+---
+
+## Skeleton / Planned Repos
+
+29 placeholder repos. Do not invest time here until MRR > £1,000.
+
+---
+
+## GitHub Issues to Resolve
+
+| Issue | Action |
+|---|---|
+| SFS-SocialPowerhouse on boweazy org | Transfer to smartflow-systems |
+| sfs-white-label-dashboard on boweazy org | Transfer to smartflow-systems |
+| SmartFlowSite-v2 and SmartFlowSite-security-fix exist | Archive/delete after verification |
+
+---
+
+## Secrets
+
+Required:
+- SFS_PAT
+
+Optional:
+- REPLIT_TOKEN
+- SFS_SYNC_URL
+
+Never expose values. Reference as environment variables only.
+
+---
+
+## Agent Roster
+
+### ChatGPT Custom GPTs
+
+| Agent | Speciality |
+|---|---|
+| Operator | Daily ops, CI/CD |
+| Build Partner | Engineering, scaffolding |
+| Consultant | Strategy, roadmap |
+| Agent | Single-repo execution |
+
+### Claude Project Agents
+
+| Agent | File | Speciality |
+|---|---|---|
+| CI/CD Agent | ci-cd-agent.md | Pipelines, deployments |
+| Stripe Agent | stripe-billing-agent.md | Billing, subscriptions |
+| White Label Agent | white-label-agent.md | Multi-tenant ops |
+| Barber Booker Agent | barber-booker-agent.md | Booking system |
+| Social Scale Agent | social-scale-agent.md | Social automation |
+| Revenue Tracker | revenue-tracker.md | MRR, pipeline, milestones |
+
+---
+
+## Output Rules
+
+- Plain talk → code.
+- No fluff.
+- Use file paths in brackets.
+- Mark overwrites.
+- Apply-All Bash must use set -euo pipefail.
+- Always include VERIFY and UNDO.
+- Keep explanations short unless deep technical detail is required.
+- Brand: black/brown/gold — Tailwind CSS + Radix UI. No exceptions.
+- Call owner “boweazy” in dev/ops context.
+- Call owner “Gareth” in public/client-facing content.
+
+---
+
+## Triggers
+
+| Trigger | Action |
+|---|---|
+| STATUS | Repo health + next 3 steps |
+| CONSOLIDATE | Full task + Apply-All + Verify + Undo |
+| DIAGNOSE | Max 2 clarifiers → fix |
+| FULL FILE [path] | Full file output |
+| ROLLBACK | Undo last action |
+| REWIND FROM HERE | Restart from clean state |
+| LET'S BASH | Output Apply-All block |
+
+---
+
+## Roadmap
+
+v0.2 → /api/boost, CORS, copy button, counter, landing copy, public link
+v0.3 → presets, save 10, webhook
+v0.4 → calendar, CSV, analytics, pricing, barber case study
+
+Revenue milestone gate: no new features until £1,000 MRR.
+
+---
+
+## Common Commands
+
+npm run dev
+npm run build
+npm run health
+git push origin main
+gh pr create
+gh run list
+gh secret list --org smartflow-systems
+
+---
+
+SFS-MASTER-CONTEXT v1.1 — corrected
+SmartFlow Systems AI Suite

--- a/docs/Secrets-Checklist.md
+++ b/docs/Secrets-Checklist.md
@@ -1,4 +1,25 @@
-﻿DO NOT PUT VALUES. Name → Where:
-SFS_PAT → GitHub Org Secret
-REPLIT_TOKEN → GitHub Org Secret
-SFS_SYNC_URL → GitHub Org Secret
+# Secrets Checklist
+
+Never store secret values in docs, screenshots, commits, or chat.
+
+## GitHub Org Secrets
+- SFS_PAT
+- REPLIT_TOKEN
+- SFS_SYNC_URL
+
+## Runtime/App Secrets
+Each app may need its own separate values:
+- DATABASE_URL
+- JWT_SECRET
+- SESSION_SECRET
+- STRIPE_SECRET_KEY
+- STRIPE_WEBHOOK_SECRET
+- OPENAI_API_KEY
+- ANTHROPIC_API_KEY
+- SENDGRID_API_KEY
+
+## Rules
+- Same secret name can exist in multiple repos.
+- Secret value should be separate per app when it protects app-specific data.
+- DATABASE_URL should usually be different per app/database.
+- Never commit .env files except .env.example.

--- a/docs/SmartFlow-Agent-Rules.md
+++ b/docs/SmartFlow-Agent-Rules.md
@@ -1,0 +1,22 @@
+# SmartFlow Agent Rules
+
+## Global Rules
+- Plain talk first, code second.
+- No fluff.
+- Use file paths in [brackets].
+- Mark overwrites clearly.
+- Never expose secret values.
+- Use black/brown/gold brand only.
+- Prioritise revenue over new builds.
+
+## Bash Rules
+- Use set -euo pipefail.
+- Include VERIFY.
+- Include UNDO for reversible operations.
+- Do not run destructive cleanup without confirmation.
+
+## Repo Rules
+- SmartFlowSite is source of truth.
+- main = production.
+- Use conventional commits: feat:, fix:, chore:, refactor:.
+- PR titles under 70 chars, imperative.

--- a/docs/codex-prompts/bugfix.md
+++ b/docs/codex-prompts/bugfix.md
@@ -1,0 +1,8 @@
+# Bugfix Task Prompt
+Fix the issue and include a regression test.
+
+Checklist:
+- Root cause summary.
+- Minimal patch.
+- Tests pass (`npm test`, and `pytest` when `app.py` exists).
+- Update changelog with VERIFY/UNDO.

--- a/docs/codex-prompts/feature.md
+++ b/docs/codex-prompts/feature.md
@@ -1,0 +1,9 @@
+# Feature Task Prompt
+Implement the requested feature with minimal blast radius.
+
+Requirements:
+- Keep branch naming and commit format compliant.
+- Add or update tests.
+- Validate DOM safety (no unsafe `innerHTML`) and ARIA labels.
+- Update `docs/CHANGELOG.md` with VERIFY and UNDO steps.
+- Provide files touched summary.

--- a/docs/codex-prompts/hardening.md
+++ b/docs/codex-prompts/hardening.md
@@ -1,0 +1,8 @@
+# Hardening Task Prompt
+Audit and harden for security and accessibility.
+
+Checklist:
+- No raw innerHTML paths.
+- Sanitization enforcement where HTML rendering is required.
+- ARIA and keyboard accessibility checks.
+- Test and changelog updates.

--- a/docs/codex-prompts/release.md
+++ b/docs/codex-prompts/release.md
@@ -1,0 +1,8 @@
+# Release Task Prompt
+Prepare release-ready changes.
+
+Checklist:
+- Verify CI workflow linkage.
+- Include deploy notes.
+- Update changelog VERIFY and UNDO.
+- Summarize risk and rollback plan.

--- a/docs/codex-setup.md
+++ b/docs/codex-setup.md
@@ -1,0 +1,23 @@
+# SFS Codex Powerhouse Setup
+
+## Workflow Rules
+- Branch format: `codex/{feature}-{YYYYMMDDHHmm}` in Europe/London time.
+- Commit format: `feat|fix|chore(scope): message`.
+- No force push.
+- Run `npm ci`, `npm test`, and `pytest` when `app.py` exists.
+
+## Codex Command Sequence
+1. `npm run doctor`
+2. `npm ci`
+3. `npm test`
+4. `pytest` (when `app.py` exists)
+5. Update `docs/CHANGELOG.md` with `VERIFY` and `UNDO`
+
+## Security and Accessibility
+- Never use raw `innerHTML`.
+- Sanitize dynamic HTML with DOMPurify.
+- Include ARIA labels for interactive controls.
+
+## CI Preference
+Use reusable workflow:
+`smartflow-systems/SmartFlowSite/.github/workflows/sfs-ci-deploy.yml@main`.

--- a/docs/revenue-tracker.md
+++ b/docs/revenue-tracker.md
@@ -1,1 +1,29 @@
-404: Not Found
+# Revenue Tracker Agent
+
+Last updated: 2026-05-22
+
+## Role
+Track SmartFlow Systems revenue, pipeline, MRR milestones, and sales execution.
+
+## Priority
+Stop building until first paying customer is closed.
+
+## Current Reality
+- £0 revenue
+- 0 paying customers
+- First target market: UK barbers and salons
+- Best first-sale products:
+  1. Barber-booker-v1
+  2. SocialScaleBooster
+
+## Revenue Rules
+- No new features until £1,000 MRR.
+- Track every lead, demo, follow-up, close/loss reason, and next action.
+- Prefer simple monthly pricing over complex tiers for first customers.
+
+## Output
+Always give:
+1. Current pipeline state
+2. Next 3 sales actions
+3. One blocker
+4. One revenue-focused recommendation

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "helmet": "^8.1.0",
         "http-proxy-middleware": "^3.0.5",
         "jsonwebtoken": "^9.0.3",
+        "marked": "^18.0.4",
         "stripe": "^20.1.0"
       },
       "devDependencies": {
@@ -5067,6 +5068,18 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.4.tgz",
+      "integrity": "sha512-c/BTaKzg0G6ezQx97DAkYU7k0HM6ys0FqYeKBL6hlBByZwy+ycA1+f0vDdjMHKKeEjdgkx0GOv9Il6D+85cOqA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "helmet": "^8.1.0",
     "http-proxy-middleware": "^3.0.5",
     "jsonwebtoken": "^9.0.3",
+    "marked": "^18.0.4",
     "stripe": "^20.1.0"
   },
   "devDependencies": {
@@ -58,7 +59,7 @@
     "terser": "^5.46.0"
   },
   "engines": {
-    "node": ">=18"
+    "node": "22.x"
   },
   "overrides": {
     "ip-address": "^10.2.0"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,10 @@
     "pull": "git pull --no-edit",
     "push": "git push",
     "auto-commit": "git add . && git commit -m 'chore: auto-commit [Auto-Sync]' || true",
-    "sync-all": "npm run auto-commit && npm run sync"
+    "sync-all": "npm run auto-commit && npm run sync",
+    "doctor": "bash scripts/sfs-doctor.sh",
+    "sfs:new-branch": "bash scripts/sfs-new-branch.sh",
+    "sfs:verify": "npm ci && npm test && if [ -f app.py ]; then pytest; else echo \"pytest skipped (no app.py)\"; fi"
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -90,9 +90,34 @@ ${body}
 </html>`;
 }
 
+function ensureSfsBlogAssets(content) {
+  if (!content.includes('<link rel="stylesheet" href="/css/sfs-complete-theme.css">')) {
+    content = content.replace(
+      '<link rel="stylesheet" href="/styles.css">',
+      '<link rel="stylesheet" href="/styles.css">\n    <link rel="stylesheet" href="/css/sfs-complete-theme.css">'
+    );
+  }
+
+  if (!content.includes('<canvas id="circuit-canvas"></canvas>')) {
+    content = content.replace('<body>', '<body>\n  <canvas id="circuit-canvas"></canvas>');
+  }
+
+  if (!content.includes('<script src="/js/sfs-circuit-flow.js"></script>')) {
+    content = content.replace(
+      '</body>',
+      '    <script src="/js/sfs-circuit-flow.js"></script>\n    <script src="/js/sfs-hamburger-menu.js"></script>\n</body>'
+    );
+  }
+
+  return content;
+}
+
 function writeFileSafe(fp, content) {
   ensureDir(path.dirname(fp));
-  fs.writeFileSync(fp, content);
+  const normalized = fp.split(path.sep).includes("blog") && fp.endsWith(".html")
+    ? ensureSfsBlogAssets(content)
+    : content;
+  fs.writeFileSync(fp, normalized);
 }
 
 /* Build blog list + individual posts */

--- a/scripts/sfs-doctor.sh
+++ b/scripts/sfs-doctor.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[sfs-doctor] Checking local environment"
+node -v
+npm -v
+python3 --version
+
+if [[ ! -f package.json ]]; then
+  echo "[sfs-doctor] package.json not found"
+  exit 1
+fi
+
+required_scripts=(doctor "sfs:new-branch" "sfs:verify" test)
+for script_name in "${required_scripts[@]}"; do
+  if npm run | rg -q "^[[:space:]]+${script_name}$"; then
+    echo "[sfs-doctor] npm script present: ${script_name}"
+  else
+    echo "[sfs-doctor] missing npm script: ${script_name}"
+    exit 1
+  fi
+done
+
+if [[ -f app.py ]]; then
+  python3 -m pytest --version
+fi
+
+echo "[sfs-doctor] OK"

--- a/scripts/sfs-new-branch.sh
+++ b/scripts/sfs-new-branch.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+feature="${1:-}"
+if [[ -z "$feature" ]]; then
+  echo "Usage: $0 <feature-name>"
+  exit 1
+fi
+
+feature_slug="$(echo "$feature" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g')"
+timestamp="$(TZ=Europe/London date +%Y%m%d%H%M)"
+branch="codex/${feature_slug}-${timestamp}"
+
+git checkout -b "$branch"
+echo "$branch"


### PR DESCRIPTION
## Summary
- harden `scripts/sfs-doctor.sh` to fail if required npm scripts are missing
- keep doctor output explicit for each required script (`doctor`, `sfs:new-branch`, `sfs:verify`, `test`)
- update `sfs:verify` script to run `npm ci` before `npm test` per SmartFlow install-first rule
- update `docs/CHANGELOG.md` with VERIFY/UNDO for this fix

## Files touched
- `scripts/sfs-doctor.sh`
- `package.json`
- `docs/CHANGELOG.md`

## VERIFY
- `npm run doctor`
- `npm run sfs:verify`
- `npm test`
- `pytest`

## UNDO
- `git revert 38dea5e`


------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f3e96de38832cb1b5609ec71d60b6)