### PR TITLE
Always allow Replit preview framing

### DIFF
--- a/server.js
+++ b/server.js
@@ -44,10 +44,7 @@ if (process.env.NODE_ENV === 'production') {
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
 
 const app = express();
-const isReplit = Boolean(process.env.REPL_ID || process.env.REPL_SLUG || process.env.REPL_OWNER);
-const frameAncestors = isReplit
-  ? ["'self'", "https://replit.com", "https://*.replit.com", "https://*.replit.dev"]
-  : ["'none'"];
+const frameAncestors = ["'self'", "https://replit.com", "https://*.replit.com", "https://*.replit.dev"];
 
 // CSP Nonce middleware - generates unique nonce for each request
 app.use((req, res, next) => {


### PR DESCRIPTION
## Summary
- always allow Replit preview hosts in the `frame-ancestors` security policy
- removes the dependency on Replit environment variables being present at runtime

## Notes
- The current main branch already includes `marked` in both `package.json` and `package-lock.json`; the missing `marked` failure appears to be from an older/stale job or another branch.

## Verification
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --cacheDirectory=.jest-cache`
- `npm run build`