### PR TITLE
Remove Dashboard link from public landing navbar

### DIFF
--- a/public/landing.html
+++ b/public/landing.html
@@ -467,7 +467,6 @@
         <li><a href="#pricing">Pricing</a></li>
         <li><a href="#testimonials">Reviews</a></li>
         <li><a href="#contact">Contact</a></li>
-        <li><a href="/admin.html" class="btn btn-ghost" style="padding: 0.5rem 1rem;">Dashboard</a></li>
       </ul>
     </div>
   </nav>

--- a/public/landing.html.backup.20251207-162431
+++ b/public/landing.html.backup.20251207-162431
@@ -467,7 +467,6 @@
         <li><a href="#pricing">Pricing</a></li>
         <li><a href="#testimonials">Reviews</a></li>
         <li><a href="#contact">Contact</a></li>
-        <li><a href="/admin.html" class="btn btn-ghost" style="padding: 0.5rem 1rem;">Dashboard</a></li>
       </ul>
     </div>
   </nav>


### PR DESCRIPTION
### Motivation
- Remove the public-facing `Dashboard` link from the navbar on the landing page to avoid exposing the admin entry point and reduce accidental access.

### Description
- Deleted the `Dashboard` navigation item linking to `/admin.html` from `public/landing.html` (and the corresponding backup file).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a27486e9648832c8275dda669f9995b)