### PR TITLE
Fix social preview metadata for custom domain

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
   <title>SmartFlow Systems — Build Smarter. Grow with Confidence.</title>
   <meta name="description" content="SmartFlow Systems builds demo-first AI-powered websites, booking tools, and business automation for UK service businesses."/>
   <meta name="theme-color" content="#0D0D0D"/>
-  <link rel="canonical" href="https://smart-flow-site.replit.app/"/>
+  <link rel="canonical" href="https://smartflowsystems.live/"/>
 
   <!-- Social preview metadata -->
   <meta property="og:type" content="website"/>
@@ -14,9 +14,9 @@
   <meta property="og:site_name" content="SmartFlow Systems"/>
   <meta property="og:title" content="SmartFlow Systems — Build Smarter. Grow with Confidence."/>
   <meta property="og:description" content="AI-powered websites, booking tools, and business automation for UK service businesses."/>
-  <meta property="og:url" content="https://smart-flow-site.replit.app/"/>
-  <meta property="og:image" content="https://smart-flow-site.replit.app/assets/smartflow-social-preview.png"/>
-  <meta property="og:image:secure_url" content="https://smart-flow-site.replit.app/assets/smartflow-social-preview.png"/>
+  <meta property="og:url" content="https://smartflowsystems.live/"/>
+  <meta property="og:image" content="https://smartflowsystems.live/assets/smartflow-social-preview.png?v=20260723"/>
+  <meta property="og:image:secure_url" content="https://smartflowsystems.live/assets/smartflow-social-preview.png?v=20260723"/>
   <meta property="og:image:type" content="image/png"/>
   <meta property="og:image:width" content="1200"/>
   <meta property="og:image:height" content="630"/>
@@ -25,7 +25,7 @@
   <meta name="twitter:card" content="summary_large_image"/>
   <meta name="twitter:title" content="SmartFlow Systems — Build Smarter. Grow with Confidence."/>
   <meta name="twitter:description" content="AI-powered websites, booking tools, and business automation for UK service businesses."/>
-  <meta name="twitter:image" content="https://smart-flow-site.replit.app/assets/smartflow-social-preview.png"/>
+  <meta name="twitter:image" content="https://smartflowsystems.live/assets/smartflow-social-preview.png?v=20260723"/>
   <meta name="twitter:image:alt" content="SmartFlow Systems — Build smarter systems. Grow with confidence."/>
 
   <link rel="icon" href="assets/favicon.png"/>


### PR DESCRIPTION
## What changed

- Pointed the canonical URL and Open Graph URL to `https://smartflowsystems.live/`
- Pointed Open Graph and X/Twitter images to the custom domain
- Added a version query to the image URL to help social platforms fetch a fresh card

## Root cause

PR #184 merged the social tags, but their URLs targeted the old Replit address. The custom domain is also still serving the pre-merge homepage, so it currently exposes no Open Graph tags.

## Validation

- Confirmed the custom domain currently has no `og:image`
- Confirmed the 1200×630 PNG exists on `main`
- Confirmed this branch changes only `public/index.html`

## Required after merge

Redeploy the Replit site from the latest `main` branch. No deployment is included in this PR.